### PR TITLE
Fix calls to shutdown_netfront in the lwip-net code

### DIFF
--- a/lwip-net.c
+++ b/lwip-net.c
@@ -315,8 +315,6 @@ static void netfrontif_exit(struct netif *netif)
 {
     struct netfrontif *nfi = netif->state;
 
-    shutdown_netfront(nfi->dev);
-
 #ifndef CONFIG_LWIP_NOTHREADS
     LWIP_DEBUGF(NETIF_DEBUG, ("netfrontif_exit: wait for thread shutdown\n"));
     nfi->_thread_exit = 1; /* request exit */
@@ -324,6 +322,11 @@ static void netfrontif_exit(struct netif *netif)
         schedule();
     LWIP_DEBUGF(NETIF_DEBUG, ("netfrontif_exit: thread was shutdown\n"));
 #endif /* CONFIG_LWIP_NOTHREADS */
+
+    if (nfi->_dev_is_private) {
+        shutdown_netfront(nfi->dev);
+        nfi->dev = NULL;
+    }
 
     if (nfi->_state_is_private) {
 	mem_free(nfi);

--- a/lwip-net.c
+++ b/lwip-net.c
@@ -465,7 +465,10 @@ err_t netfrontif_init(struct netif *netif)
     return ERR_OK;
 
 err_shutdown_netfront:
-    shutdown_netfront(nfi->dev);
+    if (nfi->_dev_is_private) {
+        shutdown_netfront(nfi->dev);
+        nfi->dev = NULL;
+    }
 err_free_nfi:
     if (nfi->_state_is_private) {
 	mem_free(nfi);


### PR DESCRIPTION
MiniOS was crashing after calling `stop_networking`, since `shutdown_netfront` was being called before the lwip thread was stopped.