### PR TITLE
mm: Improve memory usage getters torwards portability

### DIFF
--- a/arch/x86/mm.c
+++ b/arch/x86/mm.c
@@ -53,6 +53,7 @@ unsigned long *phys_to_machine_mapping;
 unsigned long mfn_zero;
 extern char stack[];
 extern void page_walk(unsigned long va);
+static unsigned long memory_size;
 
 /*
  * Make pt_pfn a new 'level' page table frame and hook it into the page
@@ -1023,6 +1024,7 @@ void arch_init_mm(unsigned long* start_pfn_p, unsigned long* max_pfn_p)
     start_pfn = PFN_UP(to_phys(start_info.pt_base)) + 
         start_info.nr_pt_frames + 3;
     max_pfn = start_info.nr_pages;
+    memory_size = start_info.nr_pages << PAGE_SHIFT;
 
     /* We need room for demand mapping and heap, clip available memory */
 #if defined(__i386__)
@@ -1042,6 +1044,11 @@ void arch_init_mm(unsigned long* start_pfn_p, unsigned long* max_pfn_p)
 
     *start_pfn_p = start_pfn;
     *max_pfn_p = max_pfn;
+}
+
+unsigned long arch_mem_size(void)
+{
+  return memory_size;
 }
 
 void arch_mm_pre_suspend(void)

--- a/include/mm.h
+++ b/include/mm.h
@@ -49,8 +49,10 @@ void free_pages(void *pointer, int order);
 #define free_page(p)    free_pages(p, 0)
 
 unsigned long mm_total_pages(void);
-unsigned long mm_reserved_pages(void);
 unsigned long mm_free_pages(void);
+unsigned long arch_mem_size(void);
+#define arch_reserved_mem() \
+    (arch_mem_size() - (mm_total_pages() << PAGE_SHIFT))
 
 static __inline__ int get_order(unsigned long size)
 {
@@ -79,7 +81,7 @@ int share_frames(unsigned long va, unsigned long orig_va, unsigned long num_fram
 unsigned long alloc_contig_pages(int order, unsigned int addr_bits);
 #ifdef HAVE_LIBC
 extern unsigned long heap, brk, heap_mapped, heap_end;
-#define mm_heap_pages() ((heap_mapped - heap) / (PAGE_SIZE))
+#define mm_heap_pages() ((heap_mapped - heap) >> PAGE_SHIFT)
 #endif
 
 int free_physical_pages(xen_pfn_t *mfns, int n);


### PR DESCRIPTION
This commit changes the getter interfaces of
Mini-OS's memory management in a way that architecture
dependent assumptions are placed in arch/.
For this purpose, the memory usage query API is changed
to the following:

arch_mem_size() *new*:
 Amount of memory (bytes) that is assigned to
 the guest.
arch_reserved_mem() *new*:
 Amount of memory (bytes) that is not used
 by Mini-OS's page allocator
 (replaces mm_reserved_pages()).
mm_total_pages() *changed*:
 Number of pages handled by MiniOS's
 page allocator.
mm_free_pages():
 Number of pages that are free
 in MiniOS's page allocator.
mm_heap_pages():
 Number of pages that are allocated
 to libc's heap (if enabled, see: sbrk()).